### PR TITLE
fix: corrects wrong stroke on SupplierOutline react svg

### DIFF
--- a/packages/ocean-icons-react/src/SupplierOutline.tsx
+++ b/packages/ocean-icons-react/src/SupplierOutline.tsx
@@ -12,7 +12,6 @@ const SupplierOutline = (
     xmlns="http://www.w3.org/2000/svg"
     fill="currentColor"
     viewBox="0 0 24 24"
-    stroke="currentColor"
     width={size}
     height={size}
     ref={svgRef}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR corrects broken SupplierOutline react SVG  in the blu_front menu icon. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work on all target platforms
- [x] I have made corresponding changes to the documentation (if appropriate)
